### PR TITLE
Fix keyboard input issues

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,7 +67,15 @@ class App extends React.Component {
     return (
       <Router>
         <div className="App">
-          <Navbar inverse={true} staticTop={true} fluid={true} collapseOnSelect={true}>
+          <Navbar
+            inverse={true}
+            staticTop={true}
+            fluid={true}
+            collapseOnSelect={true}
+            // Remove focus from the selected element to prevent it from taking
+            // further keyboard input.
+            onSelect={() => (document.activeElement as HTMLElement).blur()}
+          >
             <Navbar.Header>
               <Navbar.Brand>
                 <a href="#/">Puzzle Tools</a>

--- a/src/Braille/BrailleStream.tsx
+++ b/src/Braille/BrailleStream.tsx
@@ -28,6 +28,7 @@ class BrailleStream extends LocalStorageComponent<Props, State, SavedState> {
   constructor(props: Props) {
     super(props);
 
+    this.onKeyDown = this.onKeyDown.bind(this);
     this.onKeyPress = this.onKeyPress.bind(this);
 
     this.state = {
@@ -38,10 +39,12 @@ class BrailleStream extends LocalStorageComponent<Props, State, SavedState> {
 
   public componentDidMount() {
     super.componentDidMount();
+    document.addEventListener('keydown', this.onKeyDown);
     document.addEventListener('keypress', this.onKeyPress);
   }
 
   public componentWillUnmount() {
+    document.removeEventListener('keydown', this.onKeyDown);
     document.removeEventListener('keypress', this.onKeyPress);
   }
 
@@ -96,6 +99,25 @@ class BrailleStream extends LocalStorageComponent<Props, State, SavedState> {
     });
   }
 
+  private onKeyDown(ev: KeyboardEvent) {
+    if (ev.defaultPrevented) {
+      return;
+    }
+
+    let handled = false;
+
+    // Chrome won't trigger keypress for any keys that can invoke browser
+    // actions.
+    if (ev.keyCode === 8) { // Backspace
+      this.onBackspaceClick();
+      handled = true;
+    }
+
+    if (handled) {
+      ev.preventDefault();
+    }
+  }
+
   private onKeyPress(ev: KeyboardEvent) {
     if (ev.defaultPrevented) {
       return;
@@ -103,10 +125,7 @@ class BrailleStream extends LocalStorageComponent<Props, State, SavedState> {
 
     let handled = false;
 
-    if (ev.keyCode === 8) { // Backspace
-      this.onBackspaceClick();
-      handled = true;
-    } else if (ev.keyCode === 13 || ev.charCode === 32) { // Enter or Space
+    if (ev.keyCode === 13) { // Enter
       this.onNextClick();
       handled = true;
     } else if (ev.charCode >= 49 && ev.charCode <= 54) { // '1' through '6'

--- a/src/Morse/MorseStream.tsx
+++ b/src/Morse/MorseStream.tsx
@@ -22,6 +22,7 @@ class MorseStream extends LocalStorageComponent<Props, State, SavedState> {
   constructor(props: Props) {
     super(props);
 
+    this.onKeyDown = this.onKeyDown.bind(this);
     this.onKeyPress = this.onKeyPress.bind(this);
 
     this.state = {
@@ -32,10 +33,12 @@ class MorseStream extends LocalStorageComponent<Props, State, SavedState> {
 
   public componentDidMount() {
     super.componentDidMount();
+    document.addEventListener('keydown', this.onKeyDown);
     document.addEventListener('keypress', this.onKeyPress);
   }
 
   public componentWillUnmount() {
+    document.removeEventListener('keydown', this.onKeyDown);
     document.removeEventListener('keypress', this.onKeyPress);
   }
 
@@ -97,6 +100,25 @@ class MorseStream extends LocalStorageComponent<Props, State, SavedState> {
     });
   }
 
+  private onKeyDown(ev: KeyboardEvent) {
+    if (ev.defaultPrevented) {
+      return;
+    }
+
+    let handled = false;
+
+    // Chrome won't trigger keypress for any keys that can invoke browser
+    // actions.
+    if (ev.keyCode === 8) { // Backspace
+      this.onBackspaceClick();
+      handled = true;
+    }
+
+    if (handled) {
+      ev.preventDefault();
+    }
+  }
+
   private onKeyPress(ev: KeyboardEvent) {
     if (ev.defaultPrevented) {
       return;
@@ -104,10 +126,7 @@ class MorseStream extends LocalStorageComponent<Props, State, SavedState> {
 
     let handled = false;
 
-    if (ev.keyCode === 8) { // Backspace
-      this.onBackspaceClick();
-      handled = true;
-    } else if (ev.keyCode === 13 || ev.charCode === 32) { // Enter or Space
+    if (ev.keyCode === 13) { // Enter
       this.onNextClick();
       handled = true;
     } else if (ev.charCode === 45 || ev.charCode === 106) { // '-' or 'J'

--- a/src/Semaphore/SemaphoreStream.tsx
+++ b/src/Semaphore/SemaphoreStream.tsx
@@ -27,6 +27,7 @@ class SemaphoreStream extends LocalStorageComponent<Props, State, SavedState> {
   constructor(props: Props) {
     super(props);
 
+    this.onKeyDown = this.onKeyDown.bind(this);
     this.onKeyPress = this.onKeyPress.bind(this);
 
     this.state = {
@@ -95,6 +96,25 @@ class SemaphoreStream extends LocalStorageComponent<Props, State, SavedState> {
     });
   }
 
+  private onKeyDown(ev: KeyboardEvent) {
+    if (ev.defaultPrevented) {
+      return;
+    }
+
+    let handled = false;
+
+    // Chrome won't trigger keypress for any keys that can invoke browser
+    // actions.
+    if (ev.keyCode === 8) { // Backspace
+      this.onBackspaceClick();
+      handled = true;
+    }
+
+    if (handled) {
+      ev.preventDefault();
+    }
+  }
+
   private onKeyPress(ev: KeyboardEvent) {
     if (ev.defaultPrevented) {
       return;
@@ -102,10 +122,7 @@ class SemaphoreStream extends LocalStorageComponent<Props, State, SavedState> {
 
     let handled = false;
 
-    if (ev.keyCode === 8) { // Backspace
-      this.onBackspaceClick();
-      handled = true;
-    } else if (ev.keyCode === 13 || ev.charCode === 32) { // Enter or Space
+    if (ev.keyCode === 13) { // Enter
       this.onNextClick();
       handled = true;
     } else if (ev.charCode >= 49 && ev.charCode <= 56) { // '1' through '8'


### PR DESCRIPTION
* Remove focus from the nav bar when an element is selected
* Listen for backspace in the 'keydown' handler because Chrome prevents
  it from triggering 'keypress'

Fixes #43 
Fixes #51 