### PR TITLE
Drop support for node-chakracore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,15 @@
 dist: trusty
 language: node_js
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - libstdc++-4.9-dev
 cache:
   directories:
     - node_modules
 env:
   global:
-  - NVS_VERSION=1.4.2
+  - NVS_VERSION=1.5.2
   matrix:
   - NODEJS_VERSION=node/8
   - NODEJS_VERSION=node/10
-  - NODEJS_VERSION=node/11
-  - NODEJS_VERSION=chakracore/10
+  - NODEJS_VERSION=node/12
 before_install:
 # Install NVS.
 - git clone --branch v$NVS_VERSION --depth 1 https://github.com/jasongin/nvs ~/.nvs


### PR DESCRIPTION
One of the React modules now depends on object spread, which isn't
supported by node-chakracore.

Also upgraded NVS to v1.5.2 and swapped node/11 for node/12.